### PR TITLE
Make sure approval date is after request date

### DIFF
--- a/v1-to-v2-data-migration/helpers/transform.ts
+++ b/v1-to-v2-data-migration/helpers/transform.ts
@@ -340,8 +340,11 @@ const preProcessHistory = (eventRegistration: EventRegistration) => {
       })
 
       // Second item: APPROVE_CORRECTION
+      const approveDate = new Date(historyItem.date)
+      approveDate.setMilliseconds(approveDate.getMilliseconds() + 1)
       processedHistory.push({
         ...historyItem,
+        date: approveDate,
         action: 'APPROVED_CORRECTION',
         requestId: requestCorrectionId,
         annotation: {


### PR DESCRIPTION
Sorting can randomly change the order, causing the incorrect flag to be shown
Fixes part of : https://github.com/opencrvs/opencrvs-core/issues/11109