### PR TITLE
Fixes OTHER requester and typos

### DIFF
--- a/v1-to-v2-data-migration/helpers/dateUtils.ts
+++ b/v1-to-v2-data-migration/helpers/dateUtils.ts
@@ -10,7 +10,7 @@ export function normalizeDateString(
   }
 
   const datePattern = /^(\d{4})-(\d{1,2})-(\d{1,2})$/
-  const match = dateStr.match(datePattern)
+  const match = dateStr?.toString().match(datePattern)
 
   if (!match) {
     return dateStr
@@ -26,6 +26,5 @@ export function normalizeDateString(
 
 export function isDateField(fieldId: string): boolean {
   const dateFieldPatterns = ['BirthDate', 'birthDate', 'Date', 'deathDate']
-
   return dateFieldPatterns.some((pattern) => fieldId.includes(pattern))
 }

--- a/v1-to-v2-data-migration/helpers/historyResolver.ts
+++ b/v1-to-v2-data-migration/helpers/historyResolver.ts
@@ -1,7 +1,8 @@
 import { Certificate, HistoryItem } from './types.ts'
 
 export const collectorResolver = {
-  'collector.requesterId': (data: Certificate) => data.collector?.relationship,
+  'collector.requesterId': (data: Certificate) =>
+    other(data) ? 'SOMEONE_ELSE' : data.collector?.relationship,
   'collector.OTHER.name': (data: Certificate) =>
     other(data) && {
       surname: data.collector?.name[0].familyName, // TODO - I think I need to use the name resolver
@@ -14,11 +15,13 @@ export const collectorResolver = {
     other(data) && getId(data).type,
   'collector.PASSPORT.details': (data: Certificate) =>
     getIdForType(data, 'PASSPORT'),
-  'collector.DRIVING_LICENSE.details': (data: Certificate) =>
+  'collector.DRIVING-LICENCE.details': (data: Certificate) =>
     getIdForType(data, 'DRIVING_LICENSE'),
-  'collector.REFUGEE_NUMBER.details': (data: Certificate) =>
+  'collector.DRIVING-LICENSE.details': (data: Certificate) =>
+    getIdForType(data, 'DRIVING_LICENSE'),
+  'collector.REFUGEE-NUMBER.details': (data: Certificate) =>
     getIdForType(data, 'REFUGEE_NUMBER'),
-  'collector.ALIEN_NUMBER.details': (data: Certificate) =>
+  'collector.ALIEN-NUMBER.details': (data: Certificate) =>
     getIdForType(data, 'ALIEN_NUMBER'),
   'collector.OTHER.idTypeOther': (data: Certificate) =>
     other(data) && getId(data).otherType,
@@ -39,6 +42,9 @@ export const collectorResolver = {
     data: Certificate
   ) => data.x, // TODO
   'collector.collect.payment.data.beforeRegistrationTarget': (
+    data: Certificate
+  ) => data.x, // TODO
+  'collector.collect.payment.data.afterRegistrationTarget': (
     data: Certificate
   ) => data.x, // TODO
 }

--- a/v1-to-v2-data-migration/tests/unit/corrections.test.ts
+++ b/v1-to-v2-data-migration/tests/unit/corrections.test.ts
@@ -1563,7 +1563,7 @@ Deno.test('Corrections - with incorrectly formatted dates', async (t) => {
           },
           {
             date: '2024-01-02T12:00:00Z',
-            action: 'REQUESTED_CORRECTION',
+            action: 'CORRECTED',
             user: { id: 'user2', role: { id: 'REGISTRATION_AGENT' } },
             office: { id: 'office1' },
             input: [],
@@ -1588,6 +1588,11 @@ Deno.test('Corrections - with incorrectly formatted dates', async (t) => {
                 valueId: 'informantBirthDate',
                 value: '1966-6-6',
               },
+              {
+                valueCode: 'informant',
+                valueId: 'exactDateOfBirthUnknown',
+                value: true,
+              },
             ],
           },
         ],
@@ -1603,6 +1608,7 @@ Deno.test('Corrections - with incorrectly formatted dates', async (t) => {
         'mother.dob': '1971-01-01',
         'father.dob': '1970-06-06',
         'informant.dob': '1966-06-06',
+        'informant.dobUnknown': true,
       })
     }
   )
@@ -1648,7 +1654,7 @@ Deno.test('Corrections - with incorrectly formatted dates', async (t) => {
               {
                 valueCode: 'informant',
                 valueId: 'exactDateOfBirthUnknown',
-                value: 'false',
+                value: false,
               },
             ],
           },
@@ -1664,7 +1670,7 @@ Deno.test('Corrections - with incorrectly formatted dates', async (t) => {
         'eventDetails.date': '1971-01-01',
         'spouse.dob': '1970-06-06',
         'informant.dob': '1966-06-06',
-        'informant.dobUnknown': 'false',
+        'informant.dobUnknown': false,
       })
     }
   )


### PR DESCRIPTION
Addresses issues with the 'OTHER' requester logic and corrects typographical errors in the history resolver.

The changes include:
- Modifies the `collectorResolver` to handle the 'OTHER' requester case appropriately.
- Corrects typos in the keys of `collectorResolver`