### PR TITLE
Ignore corrections to documents as they come in an unintelligible format

### DIFF
--- a/v1-to-v2-data-migration/helpers/defaultResolvers.ts
+++ b/v1-to-v2-data-migration/helpers/defaultResolvers.ts
@@ -45,11 +45,14 @@ const informantResolver: ResolverMap = {
     !isSpecialInformant(data.informant, eventType)
       ? resolveName(data, data.informant?.name?.[0])
       : undefined, // FieldType.TEXT
-  'informant.dobUnknown': (data: EventRegistration, eventType: 'birth' | 'death') => {
-    if(isSpecialInformant(data.informant, eventType)) {
+  'informant.dobUnknown': (
+    data: EventRegistration,
+    eventType: 'birth' | 'death'
+  ) => {
+    if (isSpecialInformant(data.informant, eventType)) {
       return undefined
     }
-    if(data.informant?.birthDate) {
+    if (data.informant?.birthDate) {
       return false
     }
 
@@ -57,17 +60,19 @@ const informantResolver: ResolverMap = {
   }, // FieldType.CHECKBOX
   // @question, is this informant.age or informant.ageOfIndividualInYears?
   'informant.age': (data: EventRegistration, eventType: 'birth' | 'death') => {
-    if(isSpecialInformant(data.informant, eventType)) {
+    if (isSpecialInformant(data.informant, eventType)) {
       return undefined
     }
-    if(data.informant?.birthDate) {
+    if (data.informant?.birthDate) {
       return undefined
     }
 
-    return data.informant?.ageOfIndividualInYears && {
-      age: parseInt(data.informant?.ageOfIndividualInYears?.toString(), 10),
-      asOfDateRef: eventType == 'birth' ? 'child.dob' : 'eventDetails.date',
-    };
+    return (
+      data.informant?.ageOfIndividualInYears && {
+        age: parseInt(data.informant?.ageOfIndividualInYears?.toString(), 10),
+        asOfDateRef: eventType == 'birth' ? 'child.dob' : 'eventDetails.date',
+      }
+    )
   },
   'informant.nationality': (
     data: EventRegistration,
@@ -93,7 +98,7 @@ const informantResolver: ResolverMap = {
       : undefined,
 }
 
-const documentsResolver: ResolverMap = {
+export const documentsResolver: ResolverMap = {
   'documents.proofOfBirth': (data: EventRegistration) =>
     getDocument(data, 'CHILD'),
   'documents.proofOfMother': (data: EventRegistration) =>

--- a/v1-to-v2-data-migration/helpers/transform.ts
+++ b/v1-to-v2-data-migration/helpers/transform.ts
@@ -28,6 +28,7 @@ import {
   BIRTH_LOCATION_PRIVATE_HOME_KEY,
   COUNTRY_CODE,
 } from '../countryData/addressResolver.ts'
+import { documentsResolver } from './defaultResolvers.ts'
 
 const mappings = {
   ...DEFAULT_FIELD_MAPPINGS,
@@ -44,6 +45,9 @@ function patternMatch(
   for (const [key, value] of Object.entries(correction)) {
     const valueKey = mappings[key as keyof typeof mappings]
     if (valueKey) {
+      if (Object.keys(documentsResolver).includes(valueKey)) {
+        continue
+      }
       transformedData[valueKey] = value
     } else if (NAME_MAPPINGS[key]) {
       const nameMapping = NAME_MAPPINGS[key](value as string)
@@ -262,7 +266,7 @@ function legacyHistoryItemToV2ActionType(
         status: 'Accepted',
         type: 'REQUEST_CORRECTION' as ActionType,
         declaration: correction.output,
-        annotation: { ...annotation, ...correction.input },
+        annotation: deepMerge(annotation, correction.input),
         requestId: historyItem.id,
       }
     case 'APPROVED_CORRECTION':


### PR DESCRIPTION
Document corrections come in this form from v1, so they are not usable as correction values and when mapped, cause elasticsearch index issues.

```
           "input": [           
            {
              "valueCode": "documents",
              "valueId": "uploadDocForDeceased",
              "value": "Old Proof of deceased's ID",
              "__typename": "InputOutput"
            },
            {
              "valueCode": "documents",
              "valueId": "uploadDocForDeceasedDeath",
              "value": "Old Proof of death of deceased",
              "__typename": "InputOutput"
            }
          ],
          "output": [
            {
              "valueCode": "documents",
              "valueId": "uploadDocForDeceased",
              "value": "",
              "__typename": "InputOutput"
            },
            {
              "valueCode": "documents",
              "valueId": "uploadDocForDeceasedDeath",
              "value": "",
              "__typename": "InputOutput"
            }
          ],
```