### PR TITLE
Check age before assigning object

### DIFF
--- a/v1-to-v2-data-migration/helpers/defaultResolvers.ts
+++ b/v1-to-v2-data-migration/helpers/defaultResolvers.ts
@@ -137,10 +137,11 @@ export const defaultDeathResolver: ResolverMap = {
   'deceased.dob': (data: EventRegistration) => data.deceased?.birthDate,
   'deceased.dobUnknown': (data: EventRegistration) =>
     data.deceased?.exactDateOfBirthUnknown,
-  'deceased.age': (data: EventRegistration) => ({
-    age: data.deceased?.ageOfIndividualInYears,
-    asOfDateRef: 'eventDetails.date',
-  }),
+  'deceased.age': (data: EventRegistration) =>
+    data.deceased?.ageOfIndividualInYears && {
+      age: data.deceased?.ageOfIndividualInYears,
+      asOfDateRef: 'eventDetails.date',
+    },
   'deceased.nationality': (data: EventRegistration) =>
     data.deceased?.nationality?.[0],
   'deceased.idType': (data: EventRegistration) =>
@@ -205,10 +206,11 @@ export const defaultDeathResolver: ResolverMap = {
   'spouse.dob': (data: EventRegistration) => data.spouse?.birthDate,
   'spouse.dobUnknown': (data: EventRegistration) =>
     data.spouse?.exactDateOfBirthUnknown,
-  'spouse.age': (data: EventRegistration) => ({
-    age: data.spouse?.ageOfIndividualInYears,
-    asOfDateRef: 'eventDetails.date',
-  }),
+  'spouse.age': (data: EventRegistration) =>
+    data.spouse?.ageOfIndividualInYears && {
+      age: data.spouse?.ageOfIndividualInYears,
+      asOfDateRef: 'eventDetails.date',
+    },
   'spouse.nationality': (data: EventRegistration) =>
     data.spouse?.nationality?.[0],
   'spouse.idType': (data: EventRegistration) =>

--- a/v1-to-v2-data-migration/tests/unit/actionMapping.test.ts
+++ b/v1-to-v2-data-migration/tests/unit/actionMapping.test.ts
@@ -71,7 +71,14 @@ Deno.test('transform - basic action type mappings', async (t) => {
   await t.step(
     'should map WAITING_VALIDATION regStatus to REGISTER action with Requested status',
     () => {
-      const history = [buildHistoryItem({ regStatus: 'WAITING_VALIDATION' })]
+      const acceptedRegisterAction = buildHistoryItem({
+        regStatus: 'REGISTERED'
+      })
+
+      const history = [
+        buildHistoryItem({ regStatus: 'WAITING_VALIDATION' }),
+        acceptedRegisterAction
+      ]
       const registration = buildEventRegistration({ history })
 
       const result = transform(registration, {}, 'birth')


### PR DESCRIPTION
Fixes issue where age was null but the age object was created with a null age.

Should fix elasticsearch reindex issues. 